### PR TITLE
Fix API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ pip install -r requirements.txt
 ```
 
 3. Configura tu API Key:
-   - Edita el archivo `main.py`
-   - Reemplaza `"tu_api_key_aqui"` con tu API key real de Nebius
+   - Crea un archivo `.env` en la raíz del proyecto
+   - Añade una línea con `NEBIUS_API_KEY=<tu_api_key>`
+   - O exporta la variable de entorno `NEBIUS_API_KEY` antes de ejecutar el script
 
 ## 🎯 Uso
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,12 @@
 import os
 from openai import OpenAI
+from dotenv import load_dotenv
 
-# SOLO PARA USO LOCAL, NO SUBIR ESTA KEY A GIT
-api_key = "eyJhbGciOiJIUzI1NiIsImtpZCI6IlV6SXJWd1h0dnprLVRvdzlLZWstc0M1akptWXBvX1VaVkxUZlpnMDRlOFUiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiJnb29nbGUtb2F1dGgyfDExNDE1OTM1OTc1NjY3NDI4Mzk4NyIsInNjb3BlIjoib3BlbmlkIG9mZmxpbmVfYWNjZXNzIiwiaXNzIjoiYXBpX2tleV9pc3N1ZXIiLCJhdWQiOlsiaHR0cHM6Ly9uZWJpdXMtaW5mZXJlbmNlLmV1LmF1dGgwLmNvbS9hcGkvdjIvIl0sImV4cCI6MTkwODQxMjk1NywidXVpZCI6IjgxMTQzMGY1LTk0ODgtNDg5NC05ZDI1LTJlNDE3YmViZmMyNiIsIm5hbWUiOiJORUJJVVNfQVBJX0tFWSIsImV4cGlyZXNfYXQiOiIyMDMwLTA2LTIzVDAyOjQyOjM3KzAwMDAifQ.VY0PSlk1BB7HoKMgstjbnL3cIyIMRHWmUJmJ_zubIUg"
+load_dotenv()
+
+api_key = os.getenv("NEBIUS_API_KEY")
+if not api_key:
+    raise ValueError("NEBIUS_API_KEY environment variable not set")
 
 print("Iniciando conexión con Nebius API...")
 print(f"Longitud de la API key: {len(api_key)}")
@@ -26,4 +30,3 @@ completion = client.chat.completions.create(
 )
 
 print(completion.choices[0].message.content)
-


### PR DESCRIPTION
## Summary
- load API key from environment using `dotenv`
- update README with new configuration steps

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_685a149d19c88331926fdddaa1288db6