### PR TITLE
Add internet search tools to LangGraph agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,12 @@ Este proyecto es de código abierto y está disponible bajo la licencia MIT.
 ## 🤝 Contribuciones
 
 Las contribuciones son bienvenidas. Por favor, abre un issue o un pull request. 
+## 🤖 Agente con LangGraph
+
+El archivo `agent.py` muestra un ejemplo de agente más completo construido con **LangGraph**. Este agente soporta herramientas adicionales como conversión de imágenes, operaciones matemáticas, creación de tablas y búsqueda en Internet y Wikipedia. Para ejecutarlo:
+
+```bash
+python agent.py
+```
+
+Es posible que necesites instalar dependencias adicionales listadas en `requirements.txt`. Debido a las restricciones de red de este entorno, algunas librerías pueden no estar disponibles durante la instalación.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,137 @@
+import os
+from dotenv import load_dotenv
+
+# LangGraph and LangChain imports
+try:
+    from langgraph.graph import ChatAgent
+    from langchain_openai import ChatOpenAI
+    from langchain.agents import tool
+except ImportError:
+    # These packages may not be installed in the execution environment
+    ChatAgent = None
+    ChatOpenAI = None
+    def tool(func=None, **kwargs):
+        return func
+
+# Additional tool libraries
+try:
+    import tabily as tb
+except ImportError:
+    tb = None
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+try:
+    import sympy as sp
+except ImportError:
+    sp = None
+
+try:
+    from duckduckgo_search import DDGS
+except ImportError:
+    DDGS = None
+
+try:
+    import wikipedia
+except ImportError:
+    wikipedia = None
+
+load_dotenv()
+api_key = os.getenv("NEBIUS_API_KEY")
+if not api_key:
+    raise ValueError("NEBIUS_API_KEY environment variable not set")
+
+# Initialize the LLM client using Nebius endpoint
+llm = None
+if ChatOpenAI:
+    llm = ChatOpenAI(
+        base_url="https://api.studio.nebius.com/v1/",
+        api_key=api_key,
+        model="meta-llama/Meta-Llama-3.1-70B-Instruct",
+        temperature=0.6,
+    )
+
+# Tool definitions
+@tool
+def convert_image(input_path: str, output_path: str) -> str:
+    """Convert an image to PNG format."""
+    if Image is None:
+        return "Pillow not installed"
+    img = Image.open(input_path)
+    img.save(output_path, format="PNG")
+    return f"Saved image to {output_path}"
+
+@tool
+def evaluate_math(expression: str) -> str:
+    """Evaluate a math expression."""
+    if sp is None:
+        return "sympy not installed"
+    try:
+        result = sp.sympify(expression)
+        return str(result)
+    except Exception as e:
+        return f"Error: {e}"
+
+@tool
+def make_table(data: list) -> str:
+    """Create an ASCII table from data."""
+    if tb is None:
+        return "tabily not installed"
+    return tb.tabily(data)
+
+@tool
+def search_internet(query: str) -> str:
+    """Search the internet using DuckDuckGo."""
+    if DDGS is None:
+        return "duckduckgo-search not installed"
+    try:
+        results = []
+        with DDGS() as ddgs:
+            for r in ddgs.text(query, max_results=5):
+                results.append(r.get("body", ""))
+        return "\n".join(results)
+    except Exception as e:
+        return f"Error: {e}"
+
+@tool
+def search_wikipedia(query: str) -> str:
+    """Fetch a summary from Wikipedia."""
+    if wikipedia is None:
+        return "wikipedia not installed"
+    try:
+        return wikipedia.summary(query, sentences=2)
+    except Exception as e:
+        return f"Error: {e}"
+
+# Build the agent with LangGraph if available
+if ChatAgent and llm:
+    agent = ChatAgent(
+        llm=llm,
+        tools=[
+            convert_image,
+            evaluate_math,
+            make_table,
+            search_internet,
+            search_wikipedia,
+        ],
+    )
+else:
+    agent = None
+
+def main():
+    if agent is None:
+        print("LangGraph or dependencies missing. Agent cannot run.")
+        return
+    print("Enter a message (or 'quit'): ")
+    while True:
+        user_input = input('> ').strip()
+        if user_input.lower() == 'quit':
+            break
+        response = agent.invoke(user_input)
+        print(response)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,9 @@
 openai>=1.0.0
-python-dotenv>=1.0.0 
+python-dotenv>=1.0.0
+langchain-openai>=0.1.0
+langgraph>=0.0.10
+tabily>=0.1.0
+sympy>=1.12
+pillow>=10.0
+duckduckgo-search>=5.2.0
+wikipedia>=1.4.0


### PR DESCRIPTION
## Summary
- extend LangGraph agent with internet and Wikipedia search tools
- document these new tools in the README
- add required dependencies

## Testing
- `python -m py_compile main.py`
- `python -m py_compile agent.py`


------
https://chatgpt.com/codex/tasks/task_b_685a1615f298833181c4acabe8784800