### PR TITLE
Update key setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ cd AGENT_INICIO
 pip install -r requirements.txt
 ```
 
-3. Configura tu API Key:
-   - Crea un archivo `.env` en la raíz del proyecto
-   - Añade una línea con `NEBIUS_API_KEY=<tu_api_key>`
+3. Configura tu API Key (sin editar `main.py`):
+   - Crea un archivo `.env` en la raíz del proyecto y añade una línea con
+     `NEBIUS_API_KEY=<tu_api_key>`
    - O exporta la variable de entorno `NEBIUS_API_KEY` antes de ejecutar el script
+   - El programa leerá automáticamente esta variable; no es necesario modificar
+     `main.py`
 
 ## 🎯 Uso
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,9 @@ import os
 from openai import OpenAI
 from dotenv import load_dotenv
 
+# Carga tu API key desde un archivo `.env` o una variable de entorno.
+# Crea un archivo `.env` con `NEBIUS_API_KEY=<tu_api_key>` o exporta la variable
+# antes de ejecutar este script. No edites este archivo para agregar la clave.
 load_dotenv()
 
 api_key = os.getenv("NEBIUS_API_KEY")


### PR DESCRIPTION
## Summary
- explain how to load `NEBIUS_API_KEY` without editing the code
- clarify in `main.py` that the key should come from `.env` or an environment variable

## Testing
- `python -m py_compile main.py agent.py`
- `python main.py` *(fails: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_b_685a2a39fa188331a922ca41d9aae501